### PR TITLE
Adopt container 1.2 --kernel-arg for the BPF LSM; bump to kernel 7.1.5, kata 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Apple `container` (and most off-the-shelf macOS Linux VMs) ship a kernel that is
 missing the pieces serious eBPF work needs — no BTF, no `sched_ext`, no
 `struct_ops` qdisc, sometimes no `kprobes`/`uprobes` at all. This repo is a small
 config overlay plus three scripts that build a stock Linux stable kernel
-(currently **7.1.3**, arm64) with all of that turned on, and install it into the
+(currently **7.1.5**, arm64) with all of that turned on, and install it into the
 `container` runtime.
 
 ## What you get
@@ -23,7 +23,8 @@ A kernel with, verified present:
 - **netem** packet impairment (`tc qdisc … netem loss/delay …`) for latency and
   loss testing, plus the common classful qdiscs and BPF/u32 classifiers.
 - The **BPF LSM** with `fmod_ret` error injection (so `SEC("lsm/<hook>")` and
-  `fmod_ret` programs actually fire — see the cmdline caveat below).
+  `fmod_ret` programs actually fire — the bpf LSM is activated per run with
+  `--kernel-arg`, see below).
 - **AF_XDP** socket maps (`XSKMAP`/`DEVMAP`) so `xsk_redirect` programs load.
 
 The exact set is in [`config/ebpf-overlay.conf`](config/ebpf-overlay.conf), which
@@ -33,9 +34,15 @@ is heavily commented with the rationale and the dependency gotchas.
 
 - Apple Silicon Mac. Upstream supports `container` on **macOS 26** and states it
   does not support older releases, so that is the floor here too.
-- [Apple `container`](https://github.com/apple/container) (`brew install container`).
-- ~15 GB free disk and a few minutes (a full build took **8 minutes** on an M1
-  Max with `-j9`; see [Verified with](#verified-with)).
+- [Apple `container`](https://github.com/apple/container) **1.2.0 or newer**
+  (`brew install container`). The bpf LSM is activated per run via
+  `--kernel-arg`, which was added in 1.2.0
+  ([apple/container#1744](https://github.com/apple/container/pull/1744)); on
+  older releases everything else in the kernel still works, but there is no way
+  to add `bpf` to the active LSM list short of force-baking the whole command
+  line into the image (what this repo did before the 1.2 bump — see the caveats).
+- ~15 GB free disk and a few minutes (a full build took **9 minutes** on an M1
+  Max with `-j8`; see [Verified with](#verified-with)).
 - The kernel itself is built **inside a Linux/arm64 build container**
   (`debian:trixie`); you do not need a cross-toolchain on the host.
 
@@ -53,10 +60,10 @@ container run -d --name kbuild --cap-add ALL -c 8 -m 8G \
 # 2. build the kernel (downloads the kernel source + kata config fragments,
 #    merges the overlay, builds arch/arm64/boot/Image)
 container exec kbuild /work/scripts/build-kernel.sh
-#    -> writes /work/output/Image-7.1.3-ebpf
+#    -> writes /work/output/Image-7.1.5-ebpf
 
 # 3. install it into the runtime (host side) and restart keeping the kernel
-./scripts/install-kernel.sh ./output/Image-7.1.3-ebpf
+./scripts/install-kernel.sh ./output/Image-7.1.5-ebpf
 container system start --disable-kernel-install
 
 # 4. verify the feature set on a throwaway container
@@ -66,8 +73,9 @@ container system start --disable-kernel-install
 Expected `verify-kernel.sh` output (abridged):
 
 ```
-uname:     7.1.3-ebpf
-BTF:       present (10877109 bytes)
+uname:     7.1.5-ebpf
+cmdline:   console=hvc0 tsc=reliable panic=0 lsm=lockdown,capability,landlock,yama,apparmor,bpf oops=panic init=/sbin/vminitd ro rootfstype=ext4 root=/dev/vda
+BTF:       present (10883894 bytes)
 sched_ext: present
 lsm:       capability,landlock,bpf
 struct_ops in BTF:
@@ -76,11 +84,16 @@ struct_ops in BTF:
   bpf_struct_ops_tcp_congestion_ops
 ```
 
+The `cmdline:` line is the runtime's real command line — nothing is baked into
+the image anymore — with the `lsm=` list replaced by the one passed via
+`--kernel-arg` (that is `verify-kernel.sh` doing it; note `bpf` at the end).
+
 The `lsm:` line lists the LSMs that are **actually active**, which is only ever a
 subset of the `lsm=` on the kernel command line — the kernel silently ignores any
 LSM that is not built in. `bpf` being present is the part that matters: it is the
-proof that the forced command line took effect. The exact rest of the list varies
-with the kata fragments you build against, so do not treat it as a fingerprint.
+proof that the `--kernel-arg lsm=` override took effect. The exact rest of the
+list varies with the kata fragments you build against, so do not treat it as a
+fingerprint.
 
 ## Running BPF programs
 
@@ -104,6 +117,22 @@ Or in an already-running container:
 container exec <container> /work/scripts/setup-bpf-env.sh
 # then load / attach your BPF programs as usual
 ```
+
+If the program uses the **BPF LSM** (`SEC("lsm/<hook>")`), additionally start the
+container with the bpf LSM active — it is off by default and per run:
+
+```sh
+container run --rm --cap-add ALL \
+  --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf \
+  debian:trixie sh -c '/scripts/setup-bpf-env.sh && your-lsm-program'
+```
+
+Pass the **full list**: a user-supplied `lsm=` replaces the runtime default
+verbatim, so naming only `bpf` would silently drop `landlock`/`yama`/`apparmor`.
+Without the flag the container boots fine, but LSM programs attach and never
+fire — `setup-bpf-env.sh` prints a warning when it detects this. Only
+`SEC("lsm/…")` needs the flag; `fmod_ret`, kprobes, tracepoints, XDP and
+everything else work without it.
 
 The setup script mounts:
 
@@ -155,50 +184,43 @@ combination. It is not a compatibility claim for anything else.
 | Component | Version | How it was checked |
 |---|---|---|
 | macOS | 26.5.2 (25F84), Apple M1 Max | `sw_vers` |
-| Apple `container` | 1.1.0 | `container --version` |
-| `containerization` | 0.35.0 | exact pin of `container` 1.1.0 (`Package.resolved`) |
-| Linux kernel | 7.1.3 (`7.1.3-ebpf`) | built here, then `verify-kernel.sh` |
-| kata fragments | 3.32.0 | `KATA_TAG` default in `build-kernel.sh` |
-| Build | 8 min, `-j9`, 69 MB `Image` | `time make … Image` |
-| Date | 2026-07-15 | |
+| Apple `container` | 1.2.0 | `container --version` |
+| `containerization` | 0.40.1 | exact pin of `container` 1.2.0 (`Package.resolved`) |
+| Linux kernel | 7.1.5 (`7.1.5-ebpf`) | built here, then `verify-kernel.sh` |
+| kata fragments | 4.0.0 | `KATA_TAG` default in `build-kernel.sh` |
+| Build | 8m56s, `-j8`, 69 MB `Image` | `time make … Image` |
+| Date | 2026-08-02 | |
 
-**Why this table exists, and why it is not decoration.** The overlay sets
-`CONFIG_CMDLINE_FORCE` and bakes the runtime's *entire* kernel command line into
-the image (see the caveat below). That string is the one place this repo is
-coupled to a specific `container` release: if a future version boots with a
-different command line, the forced value goes stale and **the guest stops
-booting**. So the version of `container` this was verified against is load-bearing
-information, not trivia.
-
-On the combination above, the command line the runtime passes is:
+**Why this table exists.** Before the `container` 1.2 bump this repo force-baked
+the runtime's entire kernel command line into the image, and a runtime release
+that changed that line would have stopped the guest from booting — the table was
+the record of which release the baked string was read from. That coupling is
+gone: the image no longer forces a command line, and the bpf LSM rides on the
+`--kernel-arg` flag instead. What remains version-coupled is only that flag
+itself (`container` >= 1.2.0) and the runtime's *default* `lsm=` list, which the
+recommended override restates verbatim plus `,bpf`:
 
 ```
-console=hvc0 tsc=reliable panic=0 oops=panic lsm=lockdown,capability,landlock,yama,apparmor init=/sbin/vminitd ro rootfstype=ext4 root=/dev/vda
+lsm=lockdown,capability,landlock,yama,apparmor,bpf
 ```
 
-which is exactly `CONFIG_CMDLINE` in the overlay minus the `,bpf` this repo appends
-to `lsm=`. If you are on a newer `container`, re-check that line (see the caveat)
-before trusting this table.
+If a future `container` release changes its default LSM set, update the list in
+your `--kernel-arg` (and in `verify-kernel.sh`) to match — worst case is a
+missing LSM at runtime, not an unbootable guest.
 
 ## Important caveats
 
 - **The new kernel only affects new `container run` instances.** Existing
   containers snapshot their kernel when the runtime starts.
-- **The BPF LSM needs a forced kernel command line.** arm64 has no
-  `CMDLINE_EXTEND`, so to add `bpf` to the active `lsm=` list the overlay
-  `CONFIG_CMDLINE_FORCE`s the *entire* command line. That string must match what
-  your runtime actually boots with. **Verify it first**:
-  `container exec <some-container> cat /proc/cmdline`, then make
-  `CONFIG_CMDLINE` in the overlay match it exactly (only adding `,bpf`). A stale
-  forced command line will prevent the guest from booting. If you do not need the
-  BPF LSM, delete the two `CMDLINE` lines from the overlay.
-- **Read that command line from a kernel that is not already forcing one.** Once
-  you are running the kernel built here, `CONFIG_CMDLINE_FORCE` means the kernel
-  ignores what the runtime passed and reports `CONFIG_CMDLINE` right back at you —
-  so `cat /proc/cmdline` just echoes your own string and will "confirm" a value
-  that is already stale. Check it *before* you switch (on the stock kernel), or
-  temporarily point the runtime at a non-forcing kernel to re-read it after a
-  `container` upgrade.
+- **The BPF LSM is per-run and opt-in.** Runs without
+  `--kernel-arg lsm=…,bpf` boot fine, but `SEC("lsm/<hook>")` programs attach
+  and silently never fire. `setup-bpf-env.sh` warns when the bpf LSM is
+  inactive; `verify-kernel.sh` shows the active list.
+- **Images built before the 1.2 bump ignore `--kernel-arg`.** Those images were
+  built with `CONFIG_CMDLINE_FORCE`, which overrides whatever the runtime
+  passes — including your flags. If `verify-kernel.sh` shows a `cmdline:` that
+  does not contain the arguments you passed, you are booting one of those old
+  images; rebuild from this overlay.
 - See [`docs/troubleshooting.md`](docs/troubleshooting.md) for the BTF dependency
   chain and other traps.
 
@@ -217,7 +239,7 @@ fixes once the next stable line lands, so expect to bump `KVER` periodically
 rather than settling on it. Pick a longterm release instead if you want to sit
 still; the overlay does not care either way.
 
-The kata fragments are pinned separately via `KATA_TAG` (default `3.32.0`), and
+The kata fragments are pinned separately via `KATA_TAG` (default `4.0.0`), and
 `build-kernel.sh` also applies kata's dax patch from `patches/6.18.x/` if it still
 applies. Both are deliberately pinned rather than tracking `main`: the fragments
 decide what actually survives `olddefconfig`, so an unreviewed bump can silently

--- a/config/ebpf-overlay.conf
+++ b/config/ebpf-overlay.conf
@@ -79,20 +79,21 @@ CONFIG_NET_CLS_BPF=y
 CONFIG_FUNCTION_ERROR_INJECTION=y
 CONFIG_BPF_KPROBE_OVERRIDE=y
 #
-# The container runtime passes its own lsm= on the kernel command line, which
-# overrides CONFIG_LSM and (by default) does NOT include bpf. arm64 has no
-# CMDLINE_EXTEND -- only FROM_BOOTLOADER or FORCE -- so to add `bpf` we FORCE the
-# FULL runtime command line verbatim with `,bpf` appended to lsm=. Every other
-# token (console= / init= / root= / rootfstype=) must match what the runtime
-# actually boots with, or the guest will not start.
+# Activating the bpf LSM at boot: the runtime passes its own lsm= on the kernel
+# command line, which overrides CONFIG_LSM and does NOT include bpf. Since Apple
+# `container` 1.2.0 that default can be replaced per run (apple/container#1744):
 #
-# >>> VERIFY BEFORE USE <<<  Run `container exec <some-container> cat /proc/cmdline`
-# and make the line below match it exactly, only adding `,bpf` to lsm=. If the
-# runtime ever changes its command line, a stale forced value here bricks the boot.
-# If you do not need the BPF LSM, delete the two CMDLINE lines below (and you can
-# drop FUNCTION_ERROR_INJECTION / BPF_KPROBE_OVERRIDE too).
-CONFIG_CMDLINE_FORCE=y
-CONFIG_CMDLINE="console=hvc0 tsc=reliable panic=0 oops=panic lsm=lockdown,capability,landlock,yama,apparmor,bpf init=/sbin/vminitd ro rootfstype=ext4 root=/dev/vda"
+#   container run --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf ...
+#
+# Pass the FULL list: a user-supplied lsm= replaces the runtime default verbatim,
+# so naming only `bpf` would silently drop landlock/yama/apparmor. Runs without
+# the flag boot fine; SEC("lsm/<hook>") programs then attach but never fire.
+#
+# On container <= 1.1.x there is no --kernel-arg, and arm64 has no CMDLINE_EXTEND
+# -- the only way to add bpf there was CONFIG_CMDLINE_FORCE with the entire
+# runtime command line baked in verbatim (see this repo's history before the
+# container 1.2 bump), at the cost of the guest not booting whenever the forced
+# string went stale. This overlay no longer does that.
 
 # --- AF_XDP socket maps (XSKMAP) ---
 # Without XDP_SOCKETS, creating a BPF_MAP_TYPE_XSKMAP fails with -EINVAL and an

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -31,8 +31,8 @@ apt-get install -y --no-install-recommends \
 
 ```sh
 mkdir -p /root/build && cd /root/build
-wget https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.3.tar.xz
-tar -xf linux-7.1.3.tar.xz
+wget https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.5.tar.xz
+tar -xf linux-7.1.5.tar.xz
 ```
 
 Extract inside the container filesystem (`/root/build`), **not** on the
@@ -47,7 +47,7 @@ root, etc.). A sparse checkout pulls only the kernel packaging directory:
 
 ```sh
 cd /root/build
-git clone --depth 1 --branch 3.32.0 --filter=blob:none --sparse \
+git clone --depth 1 --branch 4.0.0 --filter=blob:none --sparse \
   https://github.com/kata-containers/kata-containers kata
 git -C kata sparse-checkout set tools/packaging/kernel
 ```
@@ -56,7 +56,7 @@ kata also carries a small dax fix that still applies cleanly to recent kernels
 (7.0.x / 7.1.x, not yet upstream). Apply it if it applies:
 
 ```sh
-cd /root/build/linux-7.1.3
+cd /root/build/linux-7.1.5
 patch -p1 --dry-run < /root/build/kata/tools/packaging/kernel/patches/6.18.x/0001-fs-dax-check-zero-or-empty-entry-before-converting-xarray.patch \
   && patch -p1 < /root/build/kata/tools/packaging/kernel/patches/6.18.x/0001-fs-dax-check-zero-or-empty-entry-before-converting-xarray.patch
 ```
@@ -97,16 +97,16 @@ see [troubleshooting.md](troubleshooting.md).
 ```sh
 : > .scmversion                      # suppress the auto "+" suffix on a tarball
 time make ARCH=arm64 LOCALVERSION=-ebpf -j8 Image
-cp arch/arm64/boot/Image /work/output/Image-7.1.3-ebpf
+cp arch/arm64/boot/Image /work/output/Image-7.1.5-ebpf
 ```
 
-A full build took 8 minutes on an M1 Max with `-j9`. The image is larger than a
+A full build took 9 minutes on an M1 Max with `-j8`. The image is larger than a
 stock VM kernel (69 MB) because it carries debug info and BTF.
 
 ## 8. Install and restart (host)
 
 ```sh
-container system kernel set --binary ./output/Image-7.1.3-ebpf --arch arm64 --force
+container system kernel set --binary ./output/Image-7.1.5-ebpf --arch arm64 --force
 container system start --disable-kernel-install
 ```
 
@@ -116,7 +116,7 @@ official one. The new kernel applies to **new** `container run` instances only.
 ## 9. Verify
 
 ```sh
-container run --rm docker.io/library/alpine:3.24 uname -r          # -> 7.1.3-ebpf
+container run --rm docker.io/library/alpine:3.24 uname -r          # -> 7.1.5-ebpf
 container run --rm docker.io/library/alpine:3.24 sh -c \
   'ls /sys/kernel/btf/vmlinux && ls -d /sys/kernel/sched_ext/'
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,58 +34,53 @@ Two separate causes:
 
 - **`bpf` isn't in the active `lsm=` list.** The VM runtime passes its own `lsm=`
   on the kernel command line, which overrides `CONFIG_LSM` and does not include
-  `bpf` by default. On arm64 there is no `CMDLINE_EXTEND` (only
-  `FROM_BOOTLOADER` or `FORCE`), so the only way to add `bpf` is to **force the
-  entire command line** with `,bpf` appended to `lsm=`. The overlay does this via
-  `CONFIG_CMDLINE_FORCE=y` + `CONFIG_CMDLINE="…"`.
+  `bpf`. Since Apple `container` 1.2.0
+  ([apple/container#1744](https://github.com/apple/container/pull/1744)) that
+  default can be replaced **per run**:
+
+  ```sh
+  container run --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf …
+  ```
+
+  Pass the full list — a user-supplied `lsm=` replaces the default verbatim, so
+  naming only `bpf` would silently drop `landlock`/`yama`/`apparmor`. The flag
+  must be on **every** run that uses `SEC("lsm/…")`; without it the container
+  boots fine and LSM programs attach but never fire (`setup-bpf-env.sh` warns
+  when it detects this). On `container` <= 1.1.x the flag does not exist; arm64
+  has no `CMDLINE_EXTEND`, so the only option there was baking the entire
+  command line into the image with `CONFIG_CMDLINE_FORCE` (what this repo did
+  before the 1.2 bump — see the repo history), at the price that a stale forced
+  string prevents the guest from booting.
 - **No `fmod_ret`-able targets.** `fmod_ret` needs
   `CONFIG_FUNCTION_ERROR_INJECTION=y` (plus `CONFIG_BPF_KPROBE_OVERRIDE=y`) for
-  there to be any attachable functions.
+  there to be any attachable functions. `fmod_ret` does **not** need `bpf` in
+  the `lsm=` list — only `SEC("lsm/…")` does.
 
 Confirm it worked: `/sys/kernel/security/lsm` should list `bpf`. The runtime does
 not mount securityfs, so that file does not exist until you mount it yourself —
 which needs `CAP_SYS_ADMIN`:
 
 ```sh
-container run --rm --cap-add SYS_ADMIN docker.io/library/debian:trixie sh -c \
+container run --rm --cap-add SYS_ADMIN \
+  --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf \
+  docker.io/library/debian:trixie sh -c \
   'mount -t securityfs securityfs /sys/kernel/security && cat /sys/kernel/security/lsm'
 # -> capability,landlock,bpf
 ```
 
 `verify-kernel.sh` does this for you. Note the list only ever contains LSMs that
-are actually built in, so it is a subset of the `lsm=` you forced on the command
-line — `bpf` being there is the thing to check, not an exact match.
+are actually built in, so it is a subset of the `lsm=` on the command line —
+`bpf` being there is the thing to check, not an exact match.
 
-### Forcing the command line can brick the boot
+### `--kernel-arg` seems to have no effect
 
-`CONFIG_CMDLINE_FORCE` bakes a fixed command line into the image. If it doesn't
-match what the runtime expects (wrong `init=`, `root=`, `console=`, …), the guest
-won't boot. Before building:
-
-```sh
-container exec <some-running-container> cat /proc/cmdline
-```
-
-Copy that string verbatim into `CONFIG_CMDLINE`, changing only `lsm=` to append
-`,bpf`. If a runtime upgrade later changes the command line, rebuild with the new
-one. If you don't need the BPF LSM at all, delete the two `CMDLINE` lines from the
-overlay and avoid the risk entirely.
-
-**Do not read `/proc/cmdline` back from the forced kernel to check this.** Once
-`CONFIG_CMDLINE_FORCE` is in effect the kernel ignores what the runtime passed and
-reports `CONFIG_CMDLINE` verbatim, so the check becomes circular: it will happily
-echo a string that no longer matches the runtime. Read it *before* switching (the
-stock kernel does not force anything), or point the runtime at a non-forcing
-kernel first:
-
-```sh
-container system kernel set --binary <stock-or-kata-kernel> --arch arm64 --force
-container system stop && container system start --disable-kernel-install
-container run --rm docker.io/library/debian:trixie cat /proc/cmdline   # the real one
-```
-
-then put your own kernel back the same way. The versions this was last checked
-against are in the README's "Verified with" table.
+If `cat /proc/cmdline` inside the guest does not show the arguments you passed,
+you are almost certainly booting an image built before the `container` 1.2 bump:
+those set `CONFIG_CMDLINE_FORCE`, which makes the kernel ignore everything the
+runtime passes — including your `--kernel-arg` flags — and report its own baked
+string back. Rebuild from the current overlay (which no longer forces a command
+line), or check which image is installed with `container system` and re-run
+`scripts/install-kernel.sh`.
 
 ## `tar` fails extracting the kernel source
 

--- a/scripts/build-kernel.sh
+++ b/scripts/build-kernel.sh
@@ -13,8 +13,8 @@
 # scripts/install-kernel.sh there.
 #
 # Tunables (environment variables):
-#   KVER         linux stable version to build           (default 7.1.3)
-#   KATA_TAG     kata-containers tag for config fragments (default 3.32.0)
+#   KVER         linux stable version to build           (default 7.1.5)
+#   KATA_TAG     kata-containers tag for config fragments (default 4.0.0)
 #   JOBS         parallel make jobs                       (default: nproc)
 #   SRC          build directory (container FS, NOT a bind mount) (default /root/build)
 #   OUT          where to drop the finished Image         (default /work/output)
@@ -22,8 +22,8 @@
 #   LOCALVERSION uname -r suffix                          (default -ebpf)
 set -euo pipefail
 
-KVER="${KVER:-7.1.3}"
-KATA_TAG="${KATA_TAG:-3.32.0}"
+KVER="${KVER:-7.1.5}"
+KATA_TAG="${KATA_TAG:-4.0.0}"
 JOBS="${JOBS:-$(nproc)}"
 SRC="${SRC:-/root/build}"
 OUT="${OUT:-/work/output}"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -3,7 +3,7 @@
 #
 # Install a freshly built kernel into Apple `container`. Run on the macOS host.
 #
-#   scripts/install-kernel.sh /path/to/Image-7.1.3-ebpf
+#   scripts/install-kernel.sh /path/to/Image-7.1.5-ebpf
 #
 # Tunables:
 #   ARCH   target architecture (default arm64)

--- a/scripts/setup-bpf-env.sh
+++ b/scripts/setup-bpf-env.sh
@@ -31,6 +31,19 @@ else
   exit 1
 fi
 
+# Warn early when the bpf LSM is not active: SEC("lsm/<hook>") programs would
+# attach but never fire. Activation is per run and needs container >= 1.2.0:
+#   container run --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf ...
+case ",$(cat /sys/kernel/security/lsm 2>/dev/null)," in
+  *,bpf,*)
+    echo "bpf lsm:    active"
+    ;;
+  *)
+    echo "bpf lsm:    NOT active — SEC(\"lsm/...\") programs will not fire" >&2
+    echo "            (re-run the container with --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf)" >&2
+    ;;
+esac
+
 # bpffs — required for BPF map pinning (pinning to /sys/fs/bpf/...)
 if mountpoint -q /sys/fs/bpf 2>/dev/null; then
   echo "bpffs:      already mounted"

--- a/scripts/verify-kernel.sh
+++ b/scripts/verify-kernel.sh
@@ -4,17 +4,26 @@
 # Verify the currently installed kernel has the eBPF feature set. Run on the
 # macOS host; it spawns a throwaway container on the active kernel.
 #
+# Needs Apple `container` >= 1.2.0: the bpf LSM is activated per run with
+# --kernel-arg (apple/container#1744). On older releases the flag does not exist
+# and this script fails to start the probe container.
+#
 # Tunables:
 #   IMAGE   container image to probe with (default debian:trixie)
 set -euo pipefail
 
 IMAGE="${IMAGE:-docker.io/library/debian:trixie}"
 
+# The full runtime default lsm= list plus bpf; a user-supplied lsm= replaces the
+# default verbatim, so listing only bpf would drop landlock/yama/apparmor.
+LSM_ARG="lsm=lockdown,capability,landlock,yama,apparmor,bpf"
+
 # SYS_ADMIN is needed for one thing only: mounting securityfs, without which the
 # active LSM list is unreadable and the `bpf` LSM cannot be verified at all.
-container run --rm --cap-add SYS_ADMIN "$IMAGE" sh -c '
+container run --rm --cap-add SYS_ADMIN --kernel-arg "$LSM_ARG" "$IMAGE" sh -c '
   set -e
   echo "uname:     $(uname -r)"
+  echo "cmdline:   $(cat /proc/cmdline)"
 
   if [ -s /sys/kernel/btf/vmlinux ]; then
     echo "BTF:       present ($(wc -c </sys/kernel/btf/vmlinux) bytes)"
@@ -38,10 +47,10 @@ container run --rm --cap-add SYS_ADMIN "$IMAGE" sh -c '
     echo "bpffs:      MISSING"
   fi
 
-  # The active LSM list; shows "bpf" only if the forced cmdline took effect. The
-  # runtime does not mount securityfs, so mount it here or the list is invisible.
-  # The list contains only LSMs actually built in, so it is a subset of the lsm=
-  # on the command line -- `bpf` being present is what matters.
+  # The active LSM list; shows "bpf" only if the --kernel-arg lsm= override took
+  # effect. The runtime does not mount securityfs, so mount it here or the list
+  # is invisible. The list contains only LSMs actually built in, so it is a
+  # subset of the lsm= on the command line -- `bpf` being present is what matters.
   mount -t securityfs securityfs /sys/kernel/security 2>/dev/null || true
   echo "lsm:       $(cat /sys/kernel/security/lsm 2>/dev/null || echo "(securityfs unavailable; needs CAP_SYS_ADMIN)")"
 


### PR DESCRIPTION
## What

- **Drop `CONFIG_CMDLINE_FORCE` from the overlay.** Since apple/container 1.2.0, a user-supplied `--kernel-arg lsm=…` replaces the runtime's default `lsm=` per run (apple/container#1744 — the upstream code comment names `lsm=...,bpf` as the intended use case). Nothing is baked into the image anymore, so a stale forced command line can no longer prevent the guest from booting.
- The bpf LSM becomes **per-run opt-in**: `container run --kernel-arg lsm=lockdown,capability,landlock,yama,apparmor,bpf …`. Runs without the flag boot fine but `SEC("lsm/…")` programs attach and never fire — `setup-bpf-env.sh` now detects and warns about that. `fmod_ret` and everything else need no flag.
- `verify-kernel.sh` passes the flag and prints the real `/proc/cmdline` (now readable truthfully, since nothing is forced).
- **KVER 7.1.3 → 7.1.5** (latest stable), **KATA_TAG 3.32.0 → 4.0.0**.
- README / docs rewritten for the new model; requirement is now container **>= 1.2.0**.

## Verified end to end (macOS 26.5.2, M1 Max, container 1.2.0 / containerization 0.40.1)

- Build 8m56s `-j8`, 69 MB Image; config check OK (all eBPF essentials survived `olddefconfig`, `CONFIG_CMDLINE=""`)
- `verify-kernel.sh`: uname `7.1.5-ebpf`, BTF 10,883,894 bytes, sched_ext present, struct_ops ×3, active lsm `capability,landlock,bpf`
- Control run **without** the flag: default cmdline is byte-identical to the one observed under 1.1.0 (runtime default unchanged in 1.2.0), warning fires
- netem-ok

## Notes

- kata 4.0.0's `common/` + `arm64/` fragments are **content-identical** to 3.32.0; the only kernel-packaging changes are gpu fragments (unused here), their build script, and a new `6.18.x/0002-virtio-fs-use-sync-release-for-submounts.patch` — that fix is already upstream in 7.1.5 (`fs/fuse/file.c`), so it needs no action.
- Images built before this change still force their baked command line and therefore **ignore** `--kernel-arg`; troubleshooting has a section on spotting that.
