### PR TITLE
Make the suggested netem check runnable on a stock image

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ uname:     7.1.5-ebpf
 cmdline:   console=hvc0 tsc=reliable panic=0 lsm=lockdown,capability,landlock,yama,apparmor,bpf oops=panic init=/sbin/vminitd ro rootfstype=ext4 root=/dev/vda
 BTF:       present (10883894 bytes)
 sched_ext: present
+bpffs:      present (not mounted — run setup-bpf-env.sh)
 lsm:       capability,landlock,bpf
 struct_ops in BTF:
   bpf_struct_ops_Qdisc_ops

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,10 +107,11 @@ Prefer `container system kernel set --binary <Image>` (a raw image) over the
 
 ```sh
 container run --rm --cap-add NET_ADMIN docker.io/library/debian:trixie sh -c \
-  'tc qdisc add dev lo root netem loss 5% && tc qdisc del dev lo root && echo netem-ok'
+  'apt-get update -qq && apt-get install -y -qq iproute2 &&
+   tc qdisc add dev lo root netem loss 5% && tc qdisc del dev lo root && echo netem-ok'
 ```
 
-(The container image also needs `iproute2` for `tc`.)
+(Stock `debian:trixie` does not ship `tc`, hence the `iproute2` install first.)
 
 ## `tracefs not found` (BPF tracepoint programs fail)
 

--- a/scripts/verify-kernel.sh
+++ b/scripts/verify-kernel.sh
@@ -64,6 +64,7 @@ container run --rm --cap-add SYS_ADMIN --kernel-arg "$LSM_ARG" "$IMAGE" sh -c '
       | sort -u | sed "s/^/  /" || echo "  (none found)"
   fi
 '
-echo ">>> netem needs CAP_NET_ADMIN; check it manually with:"
-echo "    container run --rm --cap-add NET_ADMIN $IMAGE sh -c 'tc qdisc add dev lo root netem loss 5% && tc qdisc del dev lo root && echo netem-ok'"
+echo ">>> netem needs CAP_NET_ADMIN; check it manually with (tc is not in the base"
+echo ">>> image, so iproute2 is installed first):"
+echo "    container run --rm --cap-add NET_ADMIN $IMAGE sh -c 'apt-get update -qq && apt-get install -y -qq iproute2 && tc qdisc add dev lo root netem loss 5% && tc qdisc del dev lo root && echo netem-ok'"
 echo ">>> If bpffs shows 'not mounted', run scripts/setup-bpf-env.sh inside the container first."


### PR DESCRIPTION
## Summary
- The netem check command printed by `verify-kernel.sh` (and repeated in `docs/troubleshooting.md`) fails on stock `debian:trixie` with `tc: not found` — the image does not ship `iproute2`. Fold the install into the command in both places so the copy-paste actually runs.
- Add the `bpffs: present (not mounted — run setup-bpf-env.sh)` line to the README's expected `verify-kernel.sh` output: the script really prints it on every fresh container (mounts are per-run), and its absence from the sample makes a normal result look like a failure.

## Verification
- The fixed command was run against the 7.1.5-ebpf kernel and prints `netem-ok`.