### PR TITLE
Bump kernel to 7.1.8, Apple container to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Apple `container` (and most off-the-shelf macOS Linux VMs) ship a kernel that is
 missing the pieces serious eBPF work needs — no BTF, no `sched_ext`, no
 `struct_ops` qdisc, sometimes no `kprobes`/`uprobes` at all. This repo is a small
 config overlay plus three scripts that build a stock Linux stable kernel
-(currently **7.1.5**, arm64) with all of that turned on, and install it into the
+(currently **7.1.8**, arm64) with all of that turned on, and install it into the
 `container` runtime.
 
 ## What you get
@@ -60,10 +60,10 @@ container run -d --name kbuild --cap-add ALL -c 8 -m 8G \
 # 2. build the kernel (downloads the kernel source + kata config fragments,
 #    merges the overlay, builds arch/arm64/boot/Image)
 container exec kbuild /work/scripts/build-kernel.sh
-#    -> writes /work/output/Image-7.1.5-ebpf
+#    -> writes /work/output/Image-7.1.8-ebpf
 
 # 3. install it into the runtime (host side) and restart keeping the kernel
-./scripts/install-kernel.sh ./output/Image-7.1.5-ebpf
+./scripts/install-kernel.sh ./output/Image-7.1.8-ebpf
 container system start --disable-kernel-install
 
 # 4. verify the feature set on a throwaway container
@@ -73,7 +73,7 @@ container system start --disable-kernel-install
 Expected `verify-kernel.sh` output (abridged):
 
 ```
-uname:     7.1.5-ebpf
+uname:     7.1.8-ebpf
 cmdline:   console=hvc0 tsc=reliable panic=0 lsm=lockdown,capability,landlock,yama,apparmor,bpf oops=panic init=/sbin/vminitd ro rootfstype=ext4 root=/dev/vda
 BTF:       present (10883894 bytes)
 sched_ext: present
@@ -184,9 +184,9 @@ combination. It is not a compatibility claim for anything else.
 | Component | Version | How it was checked |
 |---|---|---|
 | macOS | 26.5.2 (25F84), Apple M1 Max | `sw_vers` |
-| Apple `container` | 1.2.0 | `container --version` |
-| `containerization` | 0.40.1 | exact pin of `container` 1.2.0 (`Package.resolved`) |
-| Linux kernel | 7.1.5 (`7.1.5-ebpf`) | built here, then `verify-kernel.sh` |
+| Apple `container` | 1.2.2 | `container --version` |
+| `containerization` | 0.40.1 | exact pin of `container` 1.2.2 (`Package.resolved`) |
+| Linux kernel | 7.1.8 (`7.1.8-ebpf`) | built here, then `verify-kernel.sh` |
 | kata fragments | 4.0.0 | `KATA_TAG` default in `build-kernel.sh` |
 | Build | 8m56s, `-j8`, 69 MB `Image` | `time make … Image` |
 | Date | 2026-08-02 | |

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -31,8 +31,8 @@ apt-get install -y --no-install-recommends \
 
 ```sh
 mkdir -p /root/build && cd /root/build
-wget https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.5.tar.xz
-tar -xf linux-7.1.5.tar.xz
+wget https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.8.tar.xz
+tar -xf linux-7.1.8.tar.xz
 ```
 
 Extract inside the container filesystem (`/root/build`), **not** on the
@@ -56,7 +56,7 @@ kata also carries a small dax fix that still applies cleanly to recent kernels
 (7.0.x / 7.1.x, not yet upstream). Apply it if it applies:
 
 ```sh
-cd /root/build/linux-7.1.5
+cd /root/build/linux-7.1.8
 patch -p1 --dry-run < /root/build/kata/tools/packaging/kernel/patches/6.18.x/0001-fs-dax-check-zero-or-empty-entry-before-converting-xarray.patch \
   && patch -p1 < /root/build/kata/tools/packaging/kernel/patches/6.18.x/0001-fs-dax-check-zero-or-empty-entry-before-converting-xarray.patch
 ```
@@ -97,7 +97,7 @@ see [troubleshooting.md](troubleshooting.md).
 ```sh
 : > .scmversion                      # suppress the auto "+" suffix on a tarball
 time make ARCH=arm64 LOCALVERSION=-ebpf -j8 Image
-cp arch/arm64/boot/Image /work/output/Image-7.1.5-ebpf
+cp arch/arm64/boot/Image /work/output/Image-7.1.8-ebpf
 ```
 
 A full build took 9 minutes on an M1 Max with `-j8`. The image is larger than a
@@ -106,7 +106,7 @@ stock VM kernel (69 MB) because it carries debug info and BTF.
 ## 8. Install and restart (host)
 
 ```sh
-container system kernel set --binary ./output/Image-7.1.5-ebpf --arch arm64 --force
+container system kernel set --binary ./output/Image-7.1.8-ebpf --arch arm64 --force
 container system start --disable-kernel-install
 ```
 
@@ -116,7 +116,7 @@ official one. The new kernel applies to **new** `container run` instances only.
 ## 9. Verify
 
 ```sh
-container run --rm docker.io/library/alpine:3.24 uname -r          # -> 7.1.5-ebpf
+container run --rm docker.io/library/alpine:3.24 uname -r          # -> 7.1.8-ebpf
 container run --rm docker.io/library/alpine:3.24 sh -c \
   'ls /sys/kernel/btf/vmlinux && ls -d /sys/kernel/sched_ext/'
 ```

--- a/scripts/build-kernel.sh
+++ b/scripts/build-kernel.sh
@@ -13,7 +13,7 @@
 # scripts/install-kernel.sh there.
 #
 # Tunables (environment variables):
-#   KVER         linux stable version to build           (default 7.1.5)
+#   KVER         linux stable version to build           (default 7.1.8)
 #   KATA_TAG     kata-containers tag for config fragments (default 4.0.0)
 #   JOBS         parallel make jobs                       (default: nproc)
 #   SRC          build directory (container FS, NOT a bind mount) (default /root/build)
@@ -22,7 +22,7 @@
 #   LOCALVERSION uname -r suffix                          (default -ebpf)
 set -euo pipefail
 
-KVER="${KVER:-7.1.5}"
+KVER="${KVER:-7.1.8}"
 KATA_TAG="${KATA_TAG:-4.0.0}"
 JOBS="${JOBS:-$(nproc)}"
 SRC="${SRC:-/root/build}"

--- a/scripts/install-kernel.sh
+++ b/scripts/install-kernel.sh
@@ -3,7 +3,7 @@
 #
 # Install a freshly built kernel into Apple `container`. Run on the macOS host.
 #
-#   scripts/install-kernel.sh /path/to/Image-7.1.5-ebpf
+#   scripts/install-kernel.sh /path/to/Image-7.1.8-ebpf
 #
 # Tunables:
 #   ARCH   target architecture (default arm64)


### PR DESCRIPTION
## Summary
- Linux kernel **7.1.5 → 7.1.8** (latest stable, 2026-08-09). `KVER` default and all doc references updated.
- Apple `container` **1.2.0 → 1.2.2** (brew). The `containerization` pin is unchanged at **0.40.1**, so boot/cmdline behavior is identical to 1.2.0; 1.2.1/1.2.2 add the `k8s` plugin, `container export`, `--ssh` builds, and path masking.
- kata fragments stay at **4.0.0** (still the latest release). The kata dax patch from `patches/6.18.x/` still applies cleanly on 7.1.8.

## Verification (on-device, M-series host)
Built with `scripts/build-kernel.sh` in a debian:trixie build container (6m3s, -j9), installed with `scripts/install-kernel.sh`, then `scripts/verify-kernel.sh` under container CLI 1.2.2:

```
uname:     7.1.8-ebpf
BTF:       present (10884971 bytes)
sched_ext: present
lsm:       capability,landlock,bpf        # via --kernel-arg lsm=...,bpf
struct_ops in BTF:
  bpf_struct_ops_Qdisc_ops
  bpf_struct_ops_sched_ext_ops
  bpf_struct_ops_tcp_congestion_ops
```

netem also verified: `tc qdisc add dev lo root netem loss 5%` → `netem-ok` (CAP_NET_ADMIN).